### PR TITLE
Correct MPRIS DBus name

### DIFF
--- a/com.googleplaymusicdesktopplayer.GPMDP.json
+++ b/com.googleplaymusicdesktopplayer.GPMDP.json
@@ -21,7 +21,7 @@
       "--talk-name=com.canonical.indicator.application",
       "--talk-name=org.kde.StatusNotifierWatcher",
 
-      "--own-name=org.mpris.MediaPlayer2.google-play-music-desktop-player",
+      "--own-name=org.mpris.MediaPlayer2.google_play_music_desktop_player",
 
       "--filesystem=xdg-run/discord:create",
 


### PR DESCRIPTION
The manifest currently exposes a wrong DBus name for MPRISv2, hence playback controls are not visible and (some) hotkey configurations do not work. This PR uses the correct name as specified in GPMDP code.